### PR TITLE
ZCS-2654 Make URL pattern match case insensitive

### DIFF
--- a/conf/jetty/jetty.xml
+++ b/conf/jetty/jetty.xml
@@ -350,16 +350,8 @@
 			</Call>
 			<Call name="addRule">
 				<Arg>
-					<New class="org.eclipse.jetty.rewrite.handler.RewritePatternRule">
-						<Set name="pattern">/ews/Exchange.asmx/*</Set>
-						<Set name="replacement">/service/extension/zimbraews</Set>
-					</New>
-				</Arg>
-			</Call>
-			<Call name="addRule">
-				<Arg>
-					<New class="org.eclipse.jetty.rewrite.handler.RewritePatternRule">
-						<Set name="pattern">/EWS/Exchange.asmx/*</Set>
+					<New class="org.eclipse.jetty.rewrite.handler.RewriteRegexRule">
+						<Set name="regex">(?i)/ews/Exchange.asmx/</Set>
 						<Set name="replacement">/service/extension/zimbraews</Set>
 					</New>
 				</Arg>

--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -415,20 +415,12 @@
         </Arg>
         </Call>
         <Call name="addRule">
-          <Arg>
-             <New class="org.eclipse.jetty.rewrite.handler.RewritePatternRule">
-               <Set name="pattern">/ews/Exchange.asmx/*</Set>
-               <Set name="replacement">/service/extension/zimbraews</Set>
-             </New>
-          </Arg>
-        </Call>
-        <Call name="addRule">
-            <Arg>
-               <New class="org.eclipse.jetty.rewrite.handler.RewritePatternRule">
-                  <Set name="pattern">/EWS/Exchange.asmx/*</Set>
-                  <Set name="replacement">/service/extension/zimbraews</Set>
-               </New>
-             </Arg>
+         <Arg>
+           <New class="org.eclipse.jetty.rewrite.handler.RewriteRegexRule">
+             <Set name="regex">(?i)/ews/Exchange.asmx/</Set>
+             <Set name="replacement">/service/extension/zimbraews</Set>
+           </New>
+         </Arg>
         </Call>
         <Call name="addRule">
 	    <Arg>


### PR DESCRIPTION
ZCS-2654 Make URL pattern match case insensitive

Made the EWS URL "/ews/Exchange.asmx"  match case insensitive. 

Tested by making changes in jetty.xml.in and verifying that all the following cases are resolved and do not result in 404
https://xxxx/ews/ExchAnge.Asmx?wsdl
https://xxxx/ews/Exchange.asmx?wsdl
https://xxxx/EWS/Exchange.ASMX?wsdl
https://xxxx/ews/Exchange.ASMX?wsdl