### PR TITLE
ZCS-4380 Consolidating zimbra jars to one location

### DIFF
--- a/conf/jetty/jetty.xml
+++ b/conf/jetty/jetty.xml
@@ -583,7 +583,9 @@
 		<Set name="tempDirectory"><SystemProperty name="jetty.base" default="." />/work/service
 		</Set>
 		<Set name="compactPath">true</Set>
-  <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
+    <Set name="extraClasspath">
+    /opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
+    </Set>
 		<Call name="setAttribute">
 			<Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
 			<Arg>.*/.*jsp-api-[^/]*\.jar$|.*/.*jsp-[^/]*\.jar$|.*/.*taglibs[^/]*\.jar$</Arg>
@@ -606,7 +608,8 @@
 		</Set>
 		<Set name="persistTempDirectory">true</Set>
 		<Set name="compactPath">true</Set>
-  <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
+    <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
+    </Set>
 		<Get name="errorHandler">
 			<Call name="addErrorPage">
 				<Arg type="int">400</Arg>
@@ -640,7 +643,8 @@
 		<Set name="tempDirectory"><SystemProperty name="jetty.base" default="." />/work/zimbraAdmin
 		</Set>
 		<Set name="compactPath">true</Set>
-  <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
+    <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
+    </Set>
         <Get name="sessionHandler">
             <Get name="sessionManager">
                 <Set name="httpOnly">TRUE</Set>

--- a/conf/jetty/jetty.xml
+++ b/conf/jetty/jetty.xml
@@ -583,6 +583,7 @@
 		<Set name="tempDirectory"><SystemProperty name="jetty.base" default="." />/work/service
 		</Set>
 		<Set name="compactPath">true</Set>
+  <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
 		<Call name="setAttribute">
 			<Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
 			<Arg>.*/.*jsp-api-[^/]*\.jar$|.*/.*jsp-[^/]*\.jar$|.*/.*taglibs[^/]*\.jar$</Arg>
@@ -605,6 +606,7 @@
 		</Set>
 		<Set name="persistTempDirectory">true</Set>
 		<Set name="compactPath">true</Set>
+  <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
 		<Get name="errorHandler">
 			<Call name="addErrorPage">
 				<Arg type="int">400</Arg>
@@ -638,6 +640,7 @@
 		<Set name="tempDirectory"><SystemProperty name="jetty.base" default="." />/work/zimbraAdmin
 		</Set>
 		<Set name="compactPath">true</Set>
+  <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
         <Get name="sessionHandler">
             <Get name="sessionManager">
                 <Set name="httpOnly">TRUE</Set>

--- a/conf/jetty/jetty.xml
+++ b/conf/jetty/jetty.xml
@@ -583,9 +583,9 @@
 		<Set name="tempDirectory"><SystemProperty name="jetty.base" default="." />/work/service
 		</Set>
 		<Set name="compactPath">true</Set>
-    <Set name="extraClasspath">
-    /opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
-    </Set>
+		<Set name="extraClasspath">
+		/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
+		</Set>
 		<Call name="setAttribute">
 			<Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
 			<Arg>.*/.*jsp-api-[^/]*\.jar$|.*/.*jsp-[^/]*\.jar$|.*/.*taglibs[^/]*\.jar$</Arg>
@@ -608,8 +608,8 @@
 		</Set>
 		<Set name="persistTempDirectory">true</Set>
 		<Set name="compactPath">true</Set>
-    <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
-    </Set>
+		<Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
+		</Set>
 		<Get name="errorHandler">
 			<Call name="addErrorPage">
 				<Arg type="int">400</Arg>
@@ -643,8 +643,8 @@
 		<Set name="tempDirectory"><SystemProperty name="jetty.base" default="." />/work/zimbraAdmin
 		</Set>
 		<Set name="compactPath">true</Set>
-    <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
-    </Set>
+		<Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar
+		</Set>
         <Get name="sessionHandler">
             <Get name="sessionManager">
                 <Set name="httpOnly">TRUE</Set>

--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -655,6 +655,7 @@
       <Set name="defaultsDescriptor"><SystemProperty name="jetty.base" default="."/>/etc/webdefault.xml</Set>
       <Set name="tempDirectory"><SystemProperty name="jetty.base" default="."/>/work/service</Set>
       <Set name="compactPath">true</Set>
+      <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
       <Get name="errorHandler">
         <Call name="setShowStacks">
           <Arg type="boolean">false</Arg>
@@ -678,6 +679,7 @@
       <Set name="persistTempDirectory">true</Set>
       <Set name="compactPath">true</Set>
       <Set name="throwUnavailableOnStartupException">true</Set>
+      <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
       <Get name="errorHandler">
         <Call name="addErrorPage">
           <Arg type="int">400</Arg>
@@ -707,6 +709,7 @@
       <Set name="tempDirectory"><SystemProperty name="jetty.base" default="."/>/work/zimbraAdmin</Set>
       <Set name="compactPath">true</Set>
       <Set name="throwUnavailableOnStartupException">true</Set>
+      <Set name="extraClasspath">/opt/zimbra/lib/jars/zimbrasoap.jar,/opt/zimbra/lib/jars/zimbraclient.jar,/opt/zimbra/lib/jars/zimbrastore.jar</Set>
       <Get name="errorHandler">
         <Call name="addErrorPage">
           <Arg type="int">500</Arg>

--- a/conf/jetty/modules/zimbra.mod
+++ b/conf/jetty/modules/zimbra.mod
@@ -4,4 +4,6 @@
 
 [lib]
 common/lib/*.jar
+/opt/zimbra/lib/jars/zimbracommon.jar
+/opt/zimbra/lib/jars/zimbra-native.jar
 

--- a/conf/jetty/modules/zimbra.mod
+++ b/conf/jetty/modules/zimbra.mod
@@ -5,5 +5,5 @@
 [lib]
 common/lib/*.jar
 /opt/zimbra/lib/jars/zimbracommon.jar
-/opt/zimbra/lib/jars/zimbra-native.jar
+/opt/zimbra/lib/jars/zimbranative.jar
 


### PR DESCRIPTION
Changes made to keep zimbra jars only in /opt/zimbra/lib/jars.
Tested by making changes on server and verifying that server starts and is functional