### PR TITLE
zcs-6542:jetty upgrade to 9.4.15.xxx

### DIFF
--- a/conf/jetty/jettyrc
+++ b/conf/jetty/jettyrc
@@ -1,5 +1,5 @@
 JAVA_OPTIONS="-DSTART=${JETTY_BASE}/etc/start.config -DSTOP.PORT=7867 -DSTOP.KEY=stop -Dzimbra.config=/opt/zimbra/conf/localconfig.xml -Djava.library.path=/opt/zimbra/lib -Djava.endorsed.dirs=${JETTY_BASE}/common/endorsed -Djetty.home=${JETTY_HOME} -Djetty.base=${JETTY_BASE}"
 JETTY_CONSOLE=/opt/zimbra/log/jetty.out
 JETTY_RUN=/opt/zimbra/log
-JETTY_ARGS=" --module=zimbra,server,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}"
+JETTY_ARGS=" --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}"
 CONFIGS="etc/jetty.xml"

--- a/conf/jetty/modules/mail.mod
+++ b/conf/jetty/modules/mail.mod
@@ -1,6 +1,6 @@
-# Mail Feature
-[description]
-Adds a specific implementaion of javax.mail API based on client to the classpath.
+# Mail Module
+#Adds a specific implementaion of javax.mail API based on client to the classpath.
+#
 
 [provides]
 mail


### PR DESCRIPTION
issue : jetty was throwing unrecognised option *description* though it was also present in other .mod files.

fix : removed *description* option from mod file.

Linked PR:
https://github.com/Zimbra/zm-launcher/pull/9