### PR TITLE
Added Client Endpoint Algorithim

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -125,7 +125,7 @@
 		<Set name="KeyStorePath"><SystemProperty name="jetty.base" default="." />/etc/keystore</Set>
 		<Set name="KeyStorePassword">@@mailboxd_keystore_password@@</Set>
 		<Set name="KeyManagerPassword">@@mailboxd_keystore_password@@</Set>
-		<Set name="EndpointIdentificationAlgorithm"></Set>
+		<Set name="EndpointIdentificationAlgorithm">HTTPS</Set>
 		<Set name="renegotiationAllowed">%%zimbraMailboxdSSLRenegotiationAllowed%%</Set>
 		<!-- SSLPROTOCOLSBEGIN %%comment VAR:zimbraMailboxdSSLProtocolsXML,-->%%
 		<Set name="IncludeProtocols">


### PR DESCRIPTION
issue :  Getting warning `No Client EndPointIdentificationAlgorithm configured for SslContextFactory` in log on server start up.

fix : As per the conversation [here](https://github.com/eclipse/jetty.project/issues/3049), it is mentioned that 
>if you are confident that you have no client behaviors, (direct Jetty HttpClient use? Http2Client use? Proxy usage? AsyncMiddleManServlet usage? WebSocketClient usage? JSR356 Client usage?) then feel free to ignore that warning.
Alternatively, you could make that warning go away by just declaring a EndPointIdentificationAlgorithm (such as HTTPS) on the SslContextFactory.setEndpointIdentificationAlgorithm(String)

need to check with @rupalid  is there any client behavior which could be effected due to this change. otherwise we can use `HTTPS` as the default endpoint algorithm to avoid the warning.