### PR TITLE
ZCS-7900:SSO stoped working after update from 8.8.11

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -776,6 +776,8 @@
               <Item>org.eclipse.jetty.http.</Item>
               <Item>org.eclipse.jetty.security.</Item>
               <Item>org.eclipse.jetty.util.</Item>
+              <Item>org.eclipse.jetty.servlet.</Item>
+              <Item>org.eclipse.jetty.servlets.</Item>
            </Array>
         </Arg>
     </Call>
@@ -794,6 +796,7 @@
               <Item>-org.eclipse.jetty.servlet.DefaultServlet</Item>
               <Item>-org.eclipse.jetty.servlet.NoJspServlet</Item>
               <Item>-org.eclipse.jetty.servlet.listener.</Item>
+              <Item>-org.eclipse.jetty.servlet.</Item>
               <Item>-org.eclipse.jetty.servlets.</Item>
               <Item>-org.eclipse.jetty.server.</Item>
               <Item>-org.eclipse.jetty.io.</Item>


### PR DESCRIPTION
Porting the fix suggested in ZESC-1452