### PR TITLE
ZCS-8290: Upgrade TLS in Zimbra classic

### DIFF
--- a/conf/jetty/jetty.xml
+++ b/conf/jetty/jetty.xml
@@ -89,8 +89,6 @@
 		<Set name="IncludeProtocols">
 			<Array type="java.lang.String">
 				<!-- <Item>SSLv3</Item> -->
-				<Item>TLSv1</Item>
-				<Item>TLSv1.1</Item>
 				<Item>TLSv1.2</Item>
 			</Array>
 		</Set>


### PR DESCRIPTION
TLS1.0 and TLS1.1 support are going to expire in all major browsers, so we are making it off by default.

If users still want to use it, they need to set the values of some LDAP variables manually.