### PR TITLE
ZBUG-2633:Upgraded jetty to 9.4.46.v20220331

### DIFF
--- a/conf/jetty/modules/setuid.mod.in
+++ b/conf/jetty/modules/setuid.mod.in
@@ -6,7 +6,7 @@
 server
 
 [lib]
-lib/setuid/jetty-setuid-java-1.0.3.jar
+lib/setuid/jetty-setuid-java-1.0.4.jar
 
 [xml]
 etc/jetty-setuid.xml


### PR DESCRIPTION
Upgrade jetty to 9.4.46.v20220331

Related PR's:
https://github.com/Zimbra/zm-build/pull/205
https://github.com/Zimbra/zm-zcs-lib/pull/92
https://github.com/Zimbra/zm-mailbox/pull/1267
