### PR TITLE
ZCS-11434 : Support KeyStores with multiple certificates on the base class SslContextFactory

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -121,7 +121,7 @@
 	</Call>
 	%%comment VAR:zimbraMailLocalBind,<!--%% HTTPLOCALEND -->
     
-	<New id="zimbraSslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+	<New id="zimbraSslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 		<Set name="KeyStorePath"><SystemProperty name="jetty.base" default="." />/etc/keystore</Set>
 		<Set name="KeyStorePassword">@@mailboxd_keystore_password@@</Set>
 		<Set name="KeyManagerPassword">@@mailboxd_keystore_password@@</Set>
@@ -186,7 +186,7 @@
 
     <!-- user services connector, SSL with client certificate -->
     <!-- HTTPSCLIENTCERTBEGIN %%uncomment VAR:zimbraMailSSLClientCertMode,-->,Disabled%%
-	<New id="zimbraSslClientContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+	<New id="zimbraSslClientContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Client">
 		<Set name="KeyStorePath"><SystemProperty name="jetty.base" default="." />/etc/keystore</Set>
 		<Set name="KeyStorePassword">@@mailboxd_keystore_password@@</Set>
 		<Set name="KeyManagerPassword">@@mailboxd_keystore_password@@</Set>


### PR DESCRIPTION
**Problem :** 
Caused by: MultiException[java.lang.IllegalStateException: **KeyStores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory**. (Use org.eclipse.jetty.util.ssl.SslContextFactory$Server or org.eclipse.jetty.util.ssl.SslContextFactory$Client instead), java.lang.IllegalStateException: !STARTED: SslContextFactory@119a8125[provider=null,keyStore=file:///opt/zimbra/mailboxd/etc/keystore,trustStore=null], java.lang.IllegalStateException: !STARTED: SslContextFactory@119a8125[provider=null,keyStore=file:///opt/zimbra/mailboxd/etc/keystore,trustStore=null], java.lang.IllegalStateException: !STARTED: SslContextFactory@119a8125[provider=null,keyStore=file:///opt/zimbra/mailboxd/etc/keystore,trustStore=null]]

**Fix:** SslContextFactory() is Deprecated, need to use Client() , Server() instead.