### PR TITLE
ZCS-11457: zimlet path fix for jetty symlink failure

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -826,8 +826,8 @@
         <New class="org.eclipse.jetty.util.resource.ResourceCollection">
           <Arg>
             <Array type="String">
-              <Item><SystemProperty name="jetty.base" default="."/>/webapps/zimlet</Item>
-              <Item><SystemProperty name="jetty.base" default="."/>/../zimlets-deployed</Item>
+              <Item><SystemProperty name="jetty.zimlet.base" default="."/>/webapps/zimlet</Item>
+              <Item><SystemProperty name="jetty.zimlet.base" default="."/>/../zimlets-deployed</Item>
             </Array>
           </Arg>
         </New>

--- a/conf/jetty/jettyrc
+++ b/conf/jetty/jettyrc
@@ -1,5 +1,5 @@
-JAVA_OPTIONS="-DSTART=${JETTY_BASE}/etc/start.config -DSTOP.PORT=7867 -DSTOP.KEY=stop -Dzimbra.config=/opt/zimbra/conf/localconfig.xml -Djava.library.path=/opt/zimbra/lib -Djava.endorsed.dirs=${JETTY_BASE}/common/endorsed -Djetty.home=${JETTY_HOME} -Djetty.base=${JETTY_BASE}"
+JAVA_OPTIONS="-DSTART=${JETTY_BASE}/etc/start.config -DSTOP.PORT=7867 -DSTOP.KEY=stop -Dzimbra.config=/opt/zimbra/conf/localconfig.xml -Djava.library.path=/opt/zimbra/lib -Djava.endorsed.dirs=${JETTY_BASE}/common/endorsed -Djetty.home=${JETTY_HOME} -Djetty.base=${JETTY_BASE} -Djetty.zimlet.base=${JETTY_ZIMLET_BASE}"
 JETTY_CONSOLE=/opt/zimbra/log/jetty.out
 JETTY_RUN=/opt/zimbra/log
-JETTY_ARGS=" --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}"
+JETTY_ARGS=" --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE} jetty.zimlet.base=${JETTY_ZIMLET_BASE}"
 CONFIGS="etc/jetty.xml"


### PR DESCRIPTION
**Problem :** Jetty-9.4.46.v20220331-2 not able to get resolve path `/opt/zimbra/mailboxd` which is symlink to `/opt/zimbra/jetty_base`

`lrwxrwxrwx  1 zimbra zimbra   10 Apr 19 07:05 mailboxd -> jetty_base`

Added new parameter `jetty.zimlet.base` which is points to `/opt/zimbra/jetty_base` this will be used by jetty xml file `/opt/zimbra/jetty_base/etc/jetty.xml.in`

Related PR: https://github.com/Zimbra/zm-launcher/pull/11

