### PR TITLE
ZBUG-2831 : SMTP authentication failure with 2FA application passcode

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -38,6 +38,7 @@
 			<Arg>
 				<New class="org.eclipse.jetty.server.ForwardedRequestCustomizer">
 					<Set name="forwardedForHeader">bogus</Set>
+					<Set name="forwardedPortAsAuthority">false</Set>
 				</New>
 			</Arg>
 		</Call>


### PR DESCRIPTION
**Issue**
SMTP auth failure for account 2Fa enabled

**Fix**
During SMTP auth for 2FA enabled account there is MTA port checked from the. request, due to jetty update there is Forwarded port getting update to soap request port and the comparison fails and the authentication happens on different path causing errors. 
Added config to jetty to not update the soap request headers with forwarded port.