### PR TITLE
ZBUG-2341: Flag JSESSIONID httpOnly and secure

### DIFF
--- a/conf/jetty/webdefault.xml
+++ b/conf/jetty/webdefault.xml
@@ -354,8 +354,13 @@
 
 
   <!-- ==================================================================== -->
+
   <session-config>
     <session-timeout>5</session-timeout>
+    <cookie-config>
+      <http-only>true</http-only>
+      <secure>true</secure>
+    </cookie-config>
   </session-config>
 
   <!-- ==================================================================== -->

--- a/conf/jetty/webdefault.xml.production
+++ b/conf/jetty/webdefault.xml.production
@@ -370,8 +370,13 @@
 
 
   <!-- ==================================================================== -->
+
   <session-config>
     <session-timeout>5</session-timeout>
+    <cookie-config>
+      <http-only>true</http-only>
+      <secure>true</secure>
+    </cookie-config>
   </session-config>
 
   <!-- ==================================================================== -->


### PR DESCRIPTION
As reported in the ticket, the "JSESSIONID" and "sessionCookie" cookies need their "httpOnly" and "secure" flags set true. After trial-and-error finding what XML configuration file defines the flags, edited that to include them.

The "sessionCookie" never showed up in my browser, I couldn't find it anywhere in our code, and the bug reporter gave no answer when I asked about it.  If you know anything about it, please let me know and I'll fix it. Otherwise, I'm assuming that cookie was the result of shenanigans not directly related to Zimbra.

Tarball for testing is in [Jenkins](http://zdev-vm202.eng.zimbra.com:8080/job/ZWC_Ubuntu20_Build/75/artifact/BUILDS/UBUNTU20_64-LIBERTY-1000-20220829112720-NETWORK-1049/zcs-NETWORK-10.0.0_GA_1049.UBUNTU20_64.20220829112720.tgz).