### PR TITLE
ZBUG-2991 : use cwd of jetty process path for zimlets-deployed directory

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -827,8 +827,8 @@
         <New class="org.eclipse.jetty.util.resource.ResourceCollection">
           <Arg>
             <Array type="String">
-              <Item><SystemProperty name="jetty.zimlet.base" default="."/>/webapps/zimlet</Item>
-              <Item><SystemProperty name="jetty.zimlet.base" default="."/>/../zimlets-deployed</Item>
+		    <Item><SystemProperty name="jetty.base" default="."/>/webapps/zimlet</Item>
+		    <Item>./../zimlets-deployed</Item>
             </Array>
           </Arg>
         </New>

--- a/conf/jetty/jettyrc
+++ b/conf/jetty/jettyrc
@@ -1,5 +1,5 @@
-JAVA_OPTIONS="-DSTART=${JETTY_BASE}/etc/start.config -DSTOP.PORT=7867 -DSTOP.KEY=stop -Dzimbra.config=/opt/zimbra/conf/localconfig.xml -Djava.library.path=/opt/zimbra/lib -Djava.endorsed.dirs=${JETTY_BASE}/common/endorsed -Djetty.home=${JETTY_HOME} -Djetty.base=${JETTY_BASE} -Djetty.zimlet.base=${JETTY_ZIMLET_BASE}"
+JAVA_OPTIONS="-DSTART=${JETTY_BASE}/etc/start.config -DSTOP.PORT=7867 -DSTOP.KEY=stop -Dzimbra.config=/opt/zimbra/conf/localconfig.xml -Djava.library.path=/opt/zimbra/lib -Djava.endorsed.dirs=${JETTY_BASE}/common/endorsed -Djetty.home=${JETTY_HOME} -Djetty.base=${JETTY_BASE}"
 JETTY_CONSOLE=/opt/zimbra/log/jetty.out
 JETTY_RUN=/opt/zimbra/log
-JETTY_ARGS=" --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE} jetty.zimlet.base=${JETTY_ZIMLET_BASE}"
+JETTY_ARGS=" --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}"
 CONFIGS="etc/jetty.xml"


### PR DESCRIPTION
**Problem:**
Getting 404 HTTP error for all the requests to the /service/zimlet/ path. Jetty-9.4.46.v20220331 giving 404 error for requests which are going to the /opt/zimbra/zimlets-deployed directory. Jetty-9.4.46.v20220331 not able to resolve symlinks paths. If the path to zimlets-deployed directory contains any symlinks, jetty will fail to load it.


**Fix:**
We need to pass realpath (not symlink path) of zimlets-deployed in jetty.xml , this is being used in org.eclipse.jetty.util.resource.ResourceCollection.
To fix this issue , we need to use current working directory of jetty process path for zimlets-deployed directory. Jetty start.jar will use realpath. We can check jetty paths using below command.

```
$ cd /opt/zimbra/common/jetty_home
$ java -jar start.jar --list-config

Java Environment:
-----------------
 java.home = /SAN/zimbra/common/lib/jvm/openjdk-17.0.2-zimbra (null)
 java.vm.vendor = Oracle Corporation (null)
 java.vm.version = 17.0.2+8-86 (null)
 java.vm.name = OpenJDK 64-Bit Server VM (null)
 java.vm.info = mixed mode, sharing (null)
 java.runtime.name = OpenJDK Runtime Environment (null)
 java.runtime.version = 17.0.2+8-86 (null)
 java.io.tmpdir = /tmp (null)
 user.dir = /SAN/zimbra/common/jetty_home (null)
 user.language = en (null)
 user.country = US (null)

Jetty Environment:
-----------------
 jetty.version = 9.4.46.v20220331
 jetty.tag.version = jetty-9.4.46.v20220331
 jetty.build = bc17a0369a11ecf40bb92c839b9ef0a8ac50ea18
 jetty.home = /SAN/zimbra/common/jetty_home
 jetty.base = /SAN/zimbra/common/jetty_home

```

In above output `/SAN/zimbra/` is realpath and it is using by jetty process. So we are going to use this realpath for zimlets-deployed directory. 
Here symlink is created for zimbra directory. In this case jetty will fail to resolve symlink path ( /opt/zimbra/zimlets-deployed) and give 404 error for zimlet-deployed directory. We can avoid this issue by using realpath (/SAN/zimbra/zimlets-deployed).
```
symlink is created for zimbra
$ ls -lta zimbra
lrwxrwxrwx 1 root root 12 Jul 11 07:09 zimbra -> /SAN/zimbra/
```

```
realpath of zimlets-deployed
$ realpath  /opt/zimbra/zimlets-deployed/
/SAN/zimbra/zimlets-deployed
```
removing` jetty.zimlet.base `property as this is not required for now.


```
<Item>./../zimlets-deployed</Item>
Here . means path to the current working directory of jetty process .i.e /opt/zimbra/log
If zimbra is having symlink like zimbra -> /SAN/zimbra/ then current working directory of jetty process will be /SAN/zimbra/log
```

Related PR : https://github.com/Zimbra/zm-launcher/pull/12