### PR TITLE
ZBUG-3896 : remove nested comment as not supported in the XML

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -973,7 +973,6 @@
           </Array>
         </Set>
 
-        <!-- Modern UI uses build time compression -->
         <Set name="excludedPaths">
           <Array type="String">
             <Item>/modern/*</Item>


### PR DESCRIPTION
**Issue :** Trying to upgrade Zimbra from 8.8.15 P45 to Zimbra v10.0.6 and hitting this bug(The string "--" is not permitted within comments) 
https://forums.zimbra.org/viewtopic.php?t=72497

/opt/zimbra/log/zmmailboxd.out

```
2023-10-25 17:16:30.419:WARN:oejx.XmlParser:main: FATAL@null line:989 col:13 : org.xml.sax.SAXParseException; lineNumber: 989; columnNumber: 13; The string "--" is not permitted within comments.
2023-10-25 17:16:30.420:WARN:oejx.XmlConfiguration:main: 
java.security.PrivilegedActionException: org.xml.sax.SAXParseException; lineNumber: 989; columnNumber: 13; The string "--" is not permitted within comments.
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:573)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1857)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

```

This is reproducible with `zmprov mcf zimbraHttpCompressionEnabled FALSE`
If we set zimbraHttpCompressionEnabled to FALSE , jetty.xml having nested comments like below.

```
<!-- HTTPCOMPRESSIONBEGIN 
    <Get id="next" name="handler" />
    <Set name="handler">
      <New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
        <Set name="handler"><Ref refid="next" /></Set>
        <Set name="minGzipSize"><Property name="jetty.gzip.minGzipSize" deprecated="gzip.minGzipSize" default="2048"/></Set>
        <Set name="checkGzExists"><Property name="jetty.gzip.checkGzExists" deprecated="gzip.checkGzExists" default="false"/></Set>
        <Set name="compressionLevel"><Property name="jetty.gzip.compressionLevel" deprecated="gzip.compressionLevel" default="-1"/></Set>
        <Set name="excludedAgentPatterns">
          <Array type="String">
            <Item><Property name="jetty.gzip.excludedUserAgent" deprecated="gzip.excludedUserAgent" default=".*MSIE.6\.0.*"/></Item>
          </Array>
        </Set>

        <Set name="includedMethods">
          <Array type="String">
            <Item>GET</Item>
            <Item>POST</Item>
          </Array>
        </Set>

        <!-- Modern UI uses build time compression -->  (This is nested comment)
        <Set name="excludedPaths">
          <Array type="String">
            <Item>/modern/*</Item>
          </Array>
        </Set>
      </New>
    </Set>
     HTTPCOMPRESSIONEND -->

```